### PR TITLE
Add optional predicate for caching

### DIFF
--- a/tests/utils/test_caching.py
+++ b/tests/utils/test_caching.py
@@ -84,3 +84,39 @@ def test_cache_for_episode_different_episodes(tmp_path: Path):
         assert test_func_mock.call_count == 2
         test_func_mock.assert_any_call(episode1)
         test_func_mock.assert_any_call(episode2)
+
+
+def test_cache_for_episode_predicate_true(tmp_path: Path, podcast_rss_entry: PodcastRssEntry) -> None:
+    test_func_mock = MagicMock(return_value={TEST_DATA_KEY: TEST_DATA_VALUE})
+
+    with patch("transcription_bot.utils.caching._CACHE_FOLDER", tmp_path):
+
+        @caching.cache_for_episode(should_cache=lambda _: True)
+        def test_func(episode: PodcastRssEntry) -> dict[str, str]:
+            return test_func_mock(episode)
+
+        result1 = test_func(podcast_rss_entry)
+        result2 = test_func(podcast_rss_entry)
+
+        assert result1 == {TEST_DATA_KEY: TEST_DATA_VALUE}
+        assert result2 == result1
+        # Since predicate is True, function should be called only once
+        test_func_mock.assert_called_once_with(podcast_rss_entry)
+
+
+def test_cache_for_episode_predicate_false(tmp_path: Path, podcast_rss_entry: PodcastRssEntry) -> None:
+    test_func_mock = MagicMock(return_value={TEST_DATA_KEY: TEST_DATA_VALUE})
+
+    with patch("transcription_bot.utils.caching._CACHE_FOLDER", tmp_path):
+
+        @caching.cache_for_episode(should_cache=lambda _: False)
+        def test_func(episode: PodcastRssEntry) -> dict[str, str]:
+            return test_func_mock(episode)
+
+        result1 = test_func(podcast_rss_entry)
+        result2 = test_func(podcast_rss_entry)
+
+        assert result1 == {TEST_DATA_KEY: TEST_DATA_VALUE}
+        assert result2 == result1
+        # Since predicate is False, function should be called each time
+        assert test_func_mock.call_count == 2

--- a/transcription_bot/interfaces/azure.py
+++ b/transcription_bot/interfaces/azure.py
@@ -34,6 +34,7 @@ _session = http_client.with_auth_header(_AUTH_HEADER)
 del http_client
 
 
+@cache_for_episode(should_cache=lambda x: x is not None)
 def get_transcription(rss_entry: PodcastRssEntry) -> RawTranscript | None:
     """Get a transcription for an episode (creating if necessary)."""
     transcription_url = _send_transcription_request(rss_entry)

--- a/transcription_bot/interfaces/pyannote.py
+++ b/transcription_bot/interfaces/pyannote.py
@@ -18,6 +18,7 @@ _session = http_client.with_auth_header(_AUTH_HEADER)
 del http_client
 
 
+@cache_for_episode(should_cache=lambda x: x is not None)
 def create_diarization(rss_entry: PodcastRssEntry) -> pd.DataFrame | None:
     """Create a diarization DataFrame for the given podcast episode."""
     job_id = _send_diarization_request(rss_entry)


### PR DESCRIPTION
A better solution than what was added in #112.
Rather than never cache API returns, instead we only cache them when they return real data.