### PR TITLE
Improve detection of SoF segments

### DIFF
--- a/transcription_bot/models/episode_segments/science_or_fiction.py
+++ b/transcription_bot/models/episode_segments/science_or_fiction.py
@@ -186,7 +186,7 @@ class ScienceOrFictionSegment(FromLyricsSegment, FromShowNotesSegment):
     @override
     @staticmethod
     def match_string(lowercase_text: str) -> bool:
-        return "science or fiction" in lowercase_text
+        return lowercase_text.startswith("science or fiction")
 
     @override
     def get_start_time(self, transcript: DiarizedTranscript) -> float | None:


### PR DESCRIPTION
In episode 1047, there was an email question that contained the words "science or fiction". This led to the email segment being falsely identified as SoF.

This PR refines how we detect SoF segments. Specifically by only checking the beginning of the text. It's possible this will encounter other issues if the lyrics text changes format.